### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A Model Context Protocol server providing access to Reddit public API for LLMs. 
 
 This server uses [redditwarp](https://github.com/Pyprohly/redditwarp) to interact with Reddit's public API and exposes the functionality through MCP protocol.
 
+<a href="https://glama.ai/mcp/servers/4032xr14pu"><img width="380" height="200" src="https://glama.ai/mcp/servers/4032xr14pu/badge" alt="Server Reddit MCP server" /></a>
+
 ## Video Demo (Click to Watch)
 
 A demo in ClaudeMind 👇


### PR DESCRIPTION
This PR adds a badge for the [MCP Server Reddit](https://glama.ai/mcp/servers/4032xr14pu) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/4032xr14pu"><img width="380" height="200" src="https://glama.ai/mcp/servers/4032xr14pu/badge" alt="Server Reddit MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.